### PR TITLE
Add dispatch model

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,17 +17,30 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: "3.10"
+        miniforge-variant: Mambaforge # mamba is faster than base conda
+        miniforge-version: latest
+        activate-environment: osier-env
+        use-mamba: true
+        use-only-tar-bz2: true
+    - run: |
+        conda config --env --set pip_interop_enabled True
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install CBC
+      run: |
+        mamba install coincbc
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_design",
     "sphinx.ext.mathjax", 
-    "sphinx.ext.coverage"
+    "sphinx.ext.coverage",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,14 +32,15 @@ release = '0.1.0'
 # ones.
 extensions = [
     "myst_parser",
-    "numpydoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
-    "sphinx_design"
+    "sphinx_design",
+    "sphinx.ext.mathjax", 
+    "sphinx.ext.coverage"
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -50,6 +51,13 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'jinja2': ('https://jinja.palletsprojects.com/en/3.0.x/', None),
+    'unyt': ('https://unyt.readthedocs.io/en/stable/', None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/getting-started/index.md
+++ b/docs/source/getting-started/index.md
@@ -15,5 +15,5 @@ of [Anaconda/conda](https://www.anaconda.com/products/distribution) installed.
 Then you can install it using
 
 ```bash
-$ conda install coincbc
+$ conda install -c conda-forge coincbc
 ```

--- a/docs/source/getting-started/index.md
+++ b/docs/source/getting-started/index.md
@@ -1,0 +1,19 @@
+# Getting Started
+
+`osier` is intended to be extremely user friendly and most problems
+should be solvable without an external solver. However, the current implementation
+of the `osier.DispatchModel` as a linear program requires an external solver
+such as CPLEX, CBC, GLPK, or Gurobi (since these are all supported by `pyomo`).
+
+CPLEX and Gurobi are commercial solvers, however it is quite simple to obtain a free
+academic license (instructions forthcoming). GLPK will work on Windows, but requires
+installing external binaries. CBC is a good open-source solver for a unix operating
+system such as Mac or Linux.
+ 
+In order to use CBC on the latter two operating systems you must have a version
+of [Anaconda/conda](https://www.anaconda.com/products/distribution) installed.
+Then you can install it using
+
+```bash
+$ conda install coincbc
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,6 +17,7 @@ This package is in active development.
 
 contrib
 reference/index
+getting-started/index
 ```
 
 ## Indices and tables

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -7,5 +7,6 @@
    :template: my_class.rst
 
     osier.Technology
+    osier.DispatchModel 
     
 ```

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -10,3 +10,10 @@
     osier.DispatchModel 
     
 ```
+
+<!-- ```{toctree}
+:maxdepth: 2
+
+../contrib
+../getting-started/index
+``` -->

--- a/osier/__init__.py
+++ b/osier/__init__.py
@@ -1,1 +1,2 @@
 from .technology import *
+from .models.dispatch import *

--- a/osier/dispatch.py
+++ b/osier/dispatch.py
@@ -1,0 +1,4 @@
+import pyomo.environ as pe
+import pyomo.opt as po
+
+

--- a/osier/dispatch.py
+++ b/osier/dispatch.py
@@ -1,4 +1,0 @@
-import pyomo.environ as pe
-import pyomo.opt as po
-
-

--- a/osier/models/dispatch.py
+++ b/osier/models/dispatch.py
@@ -1,0 +1,5 @@
+import pyomo.environ as pe
+import pyomo.opt as po
+
+
+msg = "hello"

--- a/osier/models/dispatch.py
+++ b/osier/models/dispatch.py
@@ -1,5 +1,175 @@
+import pandas as pd
+import numpy as np
 import pyomo.environ as pe
 import pyomo.opt as po
+from pyomo.environ import ConcreteModel
+from unyt import unyt_array
+import itertools as it
 
 
-msg = "hello"
+class DispatchModel():
+    """
+    The :class:`DispatchModel` class creates and solves a basic dispatch
+    model from the perspective of a "grid operator." The model uses 
+    `pyomo <https://pyomo.readthedocs.io/en/stable/index.html>`_
+    to create and solve a linear programming model. 
+    The mathematical formulation for this problem is:
+
+    Minimize
+
+
+    .. math:: 
+        \\text{C}_{\\text{total}} = \\sum_t^T \\sum_u^U 
+        \\left[c^{\\text{fuel}}_{u,t} + c^{\\text{om,var}}_{u,t}\\right]x_{u,t}
+
+    Such that,
+
+    .. math::
+        \\sum_t^Tx_u &\\geq \\left(1-\\text{undersupply}\\right)\\text{D}_t \\
+        \\forall \\ t \\in T
+
+        \\sum_t^Tx_u &\\leq \\left(1+\\text{oversupply}\\right)\\text{D}_t \\
+        \\forall \\ t \\in T
+        
+
+    Parameters
+    ----------
+    technology_list : list of :class:`osier.Technology`
+        The list of :class:`Technology` objects to dispatch -- i.e. decide
+        how much energy each technology should produce.
+    net_demand : List, :class:`numpy.ndarray`, :class:`unyt.array.unyt_array`
+        The remaining energy demand to be fulfilled by the technologies in
+        :attr:`technology_list`. For example:
+
+        >>> from osier import DispatchModel
+        >>> from osier import Technology
+        >>> wind = Technology("wind")
+        >>> nuclear = Technology("nuclear")
+        >>> import numpy as np
+        >>> hours = np.arange(24)
+        >>> demand = np.cos(hours*np.pi/180)
+        >>> model = DispatchModel([wind, nuclear], demand)
+        >>> model.solve()
+    """
+    def __init__(self, 
+                 technology_list,
+                 net_demand,
+                 solver='cplex',
+                 lower_bound=0.0,
+                 oversupply = 0.0,
+                 undersupply = 0.0):
+        self.net_demand = net_demand
+        self.technology_list = technology_list
+        self.lower_bound = lower_bound
+        self.oversupply = oversupply
+        self.undersupply = undersupply
+        self.model = ConcreteModel()
+        self.solver = solver
+        self.results = None
+    
+    @property
+    def n_hours(self):
+        return len(self.net_demand)
+    
+    @property
+    def tech_set(self):
+        tech_names = [t.technology_name for t in self.technology_list]
+        return tech_names
+    
+    @property
+    def capacity_dict(self):
+        capacity_set = unyt_array([t.capacity for t in self.technology_list])
+        return dict(zip(self.tech_set, capacity_set))
+    
+    @property
+    def time_set(self):
+        return range(self.n_hours)
+    
+    @property
+    def indices(self):
+        return list(it.product(self.tech_set, self.time_set))
+    
+    @property
+    def cost_params(self):
+        v_costs = np.array([
+                            (t.variable_cost_ts(self.n_hours))
+                            for t in self.technology_list
+                        ]).flatten()
+        return dict(zip(self.indices, v_costs))
+    
+    @property
+    def upper_bound(self):
+        caps = unyt_array([t.capacity for t in self.technology_list])
+        return caps.max().to_value()
+    
+    def _create_model_indices(self):
+        self.model.U = pe.Set(initialize=self.tech_set, ordered=True)
+        self.model.T = pe.Set(initialize=self.time_set, ordered=True)
+    
+    def _create_demand_param(self):
+        self.model.D = pe.Param(self.model.T, initialize=dict(zip(self.model.T, self.net_demand)))
+    
+    def _create_cost_param(self):
+        self.model.C = pe.Param(self.model.U, self.model.T, initialize=self.cost_params)
+
+    
+    def _create_model_variables(self):
+        self.model.x = pe.Var(self.model.U, self.model.T, 
+                              domain=pe.Reals, 
+                              bounds=(self.lower_bound, self.upper_bound))
+        
+    def _objective_function(self):
+        expr = sum(self.model.C[u, t] * self.model.x[u, t]
+                   for u in self.model.U for t in self.model.T)
+        self.model.objective = pe.Objective(sense=pe.minimize, expr=expr)
+        
+    def _oversupply_constraint(self):
+        self.model.oversupply = pe.ConstraintList()
+        for t in self.model.T:
+            generation = sum(self.model.x[u, t] for u in self.model.U)
+            over_demand = self.model.D[t] * (1+self.oversupply)
+            self.model.oversupply.add(generation <= over_demand)
+            
+    def _undersupply_constraint(self):
+        self.model.undersupply = pe.ConstraintList()
+        for t in self.model.T:
+            generation = sum(self.model.x[u, t] for u in self.model.U)
+            under_demand = self.model.D[t] * (1-self.undersupply)
+            self.model.undersupply.add(generation >= under_demand)
+            
+    def _generation_constraint(self):
+        self.model.gen_limit = pe.ConstraintList()
+        for t in self.model.T:
+            for u in self.model.U:
+                unit_generation = self.model.x[u, t]
+                unit_capacity = self.capacity_dict[u].to_value()
+                self.model.gen_limit.add(unit_generation <= unit_capacity)
+
+    
+    def _write_model_equations(self):
+        
+        self._create_model_indices()
+        self._create_demand_param()
+        self._create_cost_param()
+        self._create_model_variables()
+        self._objective_function()
+        self._oversupply_constraint()
+        self._undersupply_constraint()
+        self._generation_constraint()
+        
+        return
+    
+    def _format_results(self):
+        df = pd.DataFrame(index=self.model.T)
+        for u in self.model.U:
+            df[u] = [self.model.x[u,t].value for t in self.model.T]
+            
+        return df
+        
+        
+    def solve(self):
+        self._write_model_equations()
+        solver = po.SolverFactory(self.solver)
+        results = solver.solve(self.model, tee=True)
+        
+        self.results = self._format_results()        

--- a/osier/models/dispatch.py
+++ b/osier/models/dispatch.py
@@ -24,12 +24,19 @@ class DispatchModel():
 
     Such that,
 
+    1. The generation meets demand within a user-specified tolerance (undersupply and oversupply)
+ 
     .. math::
-        \\sum_t^Tx_u &\\geq \\left(1-\\text{undersupply}\\right)\\text{D}_t \\
+        \\sum_u^Ux_{u,t} &\\geq \\left(1-\\text{undersupply}\\right)\\text{D}_t \\
         \\forall \\ t \\in T
 
-        \\sum_t^Tx_u &\\leq \\left(1+\\text{oversupply}\\right)\\text{D}_t \\
+        \\sum_u^Ux_{u,t} &\\leq \\left(1+\\text{oversupply}\\right)\\text{D}_t \\
         \\forall \\ t \\in T
+
+    2. A technology's generation (:math:`x_u`) does not exceed its capacity to generate at any time, :math:`t`.
+    
+    .. math::
+        x_{u,t} \\leq \\textbf{CAP}_{u} \\ \\forall \\ u,t \\in U,T
         
 
     Parameters
@@ -63,6 +70,15 @@ class DispatchModel():
     undersupply : float
         The amount of allowed undersupply as a percentage of demand.
         Default is 0.0 (no undersupply allowed).
+
+    Attributes
+    ----------
+    model : :class:`pyomo.environ.ConcreteModel`
+        The :mod:`pyomo` model class that converts python code into a
+        set of linear equations.
+    upperbound : float
+        The upper bound for all decision variables. Chosen to be equal
+        to the maximum capacity for 
     """
     def __init__(self, 
                  technology_list,

--- a/osier/models/dispatch.py
+++ b/osier/models/dispatch.py
@@ -50,6 +50,19 @@ class DispatchModel():
         >>> demand = np.cos(hours*np.pi/180)
         >>> model = DispatchModel([wind, nuclear], demand)
         >>> model.solve()
+
+    solver : str 
+        Indicates which solver to use. May require separate installation.
+        Accepts: ['cplex']. Other solvers will be added in the future.
+    lower_bound : float
+        The least amount of energy each technology can produce per time
+        period. Default is 0.0.
+    oversupply : float
+        The amount of allowed oversupply as a percentage of demand.
+        Default is 0.0 (no oversupply allowed). 
+    undersupply : float
+        The amount of allowed undersupply as a percentage of demand.
+        Default is 0.0 (no undersupply allowed).
     """
     def __init__(self, 
                  technology_list,

--- a/osier/models/dispatch.py
+++ b/osier/models/dispatch.py
@@ -79,6 +79,7 @@ class DispatchModel():
         self.model = ConcreteModel()
         self.solver = solver
         self.results = None
+        self.objective = None
     
     @property
     def n_hours(self):
@@ -184,5 +185,6 @@ class DispatchModel():
         self._write_model_equations()
         solver = po.SolverFactory(self.solver)
         results = solver.solve(self.model, tee=True)
+        self.objective = self.model.objective()
         
         self.results = self._format_results()        

--- a/osier/models/dispatch.py
+++ b/osier/models/dispatch.py
@@ -187,8 +187,6 @@ class DispatchModel():
         self._supply_constraints()
         self._generation_constraint()
 
-        return
-
     def _format_results(self):
         df = pd.DataFrame(index=self.model.T)
         for u in self.model.U:

--- a/osier/models/dispatch.py
+++ b/osier/models/dispatch.py
@@ -10,34 +10,36 @@ import itertools as it
 class DispatchModel():
     """
     The :class:`DispatchModel` class creates and solves a basic dispatch
-    model from the perspective of a "grid operator." The model uses 
+    model from the perspective of a "grid operator." The model uses
     `pyomo <https://pyomo.readthedocs.io/en/stable/index.html>`_
-    to create and solve a linear programming model. 
+    to create and solve a linear programming model.
     The mathematical formulation for this problem is:
 
     Minimize
 
 
-    .. math:: 
-        \\text{C}_{\\text{total}} = \\sum_t^T \\sum_u^U 
+    .. math::
+        \\text{C}_{\\text{total}} = \\sum_t^T \\sum_u^U
         \\left[c^{\\text{fuel}}_{u,t} + c^{\\text{om,var}}_{u,t}\\right]x_{u,t}
 
     Such that,
 
-    1. The generation meets demand within a user-specified tolerance (undersupply and oversupply)
- 
+    1. The generation meets demand within a user-specified tolerance
+    (undersupply and oversupply)
+
     .. math::
-        \\sum_u^Ux_{u,t} &\\geq \\left(1-\\text{undersupply}\\right)\\text{D}_t \\
-        \\forall \\ t \\in T
+        \\sum_u^Ux_{u,t} &\\geq \\left(1-\\text{undersupply}\\right)\\text{D}_t
+        \\ \\forall \\ t \\in T
 
-        \\sum_u^Ux_{u,t} &\\leq \\left(1+\\text{oversupply}\\right)\\text{D}_t \\
-        \\forall \\ t \\in T
+        \\sum_u^Ux_{u,t} &\\leq \\left(1+\\text{oversupply}\\right)\\text{D}_t 
+        \\ \\forall \\ t \\in T
 
-    2. A technology's generation (:math:`x_u`) does not exceed its capacity to generate at any time, :math:`t`.
-    
+    2. A technology's generation (:math:`x_u`) does not exceed its capacity to
+    generate at any time, :math:`t`.
+
     .. math::
         x_{u,t} \\leq \\textbf{CAP}_{u} \\ \\forall \\ u,t \\in U,T
-        
+
 
     Parameters
     ----------
@@ -58,7 +60,7 @@ class DispatchModel():
         >>> model = DispatchModel([wind, nuclear], demand)
         >>> model.solve()
 
-    solver : str 
+    solver : str
         Indicates which solver to use. May require separate installation.
         Accepts: ['cplex']. Other solvers will be added in the future.
     lower_bound : float
@@ -66,7 +68,7 @@ class DispatchModel():
         period. Default is 0.0.
     oversupply : float
         The amount of allowed oversupply as a percentage of demand.
-        Default is 0.0 (no oversupply allowed). 
+        Default is 0.0 (no oversupply allowed).
     undersupply : float
         The amount of allowed undersupply as a percentage of demand.
         Default is 0.0 (no undersupply allowed).
@@ -78,15 +80,16 @@ class DispatchModel():
         set of linear equations.
     upperbound : float
         The upper bound for all decision variables. Chosen to be equal
-        to the maximum capacity for 
+        to the maximum capacity for
     """
-    def __init__(self, 
+
+    def __init__(self,
                  technology_list,
                  net_demand,
                  solver='cplex',
                  lower_bound=0.0,
-                 oversupply = 0.0,
-                 undersupply = 0.0):
+                 oversupply=0.0,
+                 undersupply=0.0):
         self.net_demand = net_demand
         self.technology_list = technology_list
         self.lower_bound = lower_bound
@@ -96,77 +99,80 @@ class DispatchModel():
         self.solver = solver
         self.results = None
         self.objective = None
-    
+
     @property
     def n_hours(self):
         return len(self.net_demand)
-    
+
     @property
     def tech_set(self):
         tech_names = [t.technology_name for t in self.technology_list]
         return tech_names
-    
+
     @property
     def capacity_dict(self):
         capacity_set = unyt_array([t.capacity for t in self.technology_list])
         return dict(zip(self.tech_set, capacity_set))
-    
+
     @property
     def time_set(self):
         return range(self.n_hours)
-    
+
     @property
     def indices(self):
         return list(it.product(self.tech_set, self.time_set))
-    
+
     @property
     def cost_params(self):
         v_costs = np.array([
-                            (t.variable_cost_ts(self.n_hours))
-                            for t in self.technology_list
-                        ]).flatten()
+            (t.variable_cost_ts(self.n_hours))
+            for t in self.technology_list
+        ]).flatten()
         return dict(zip(self.indices, v_costs))
-    
+
     @property
     def upper_bound(self):
         caps = unyt_array([t.capacity for t in self.technology_list])
         return caps.max().to_value()
-    
+
     def _create_model_indices(self):
         self.model.U = pe.Set(initialize=self.tech_set, ordered=True)
         self.model.T = pe.Set(initialize=self.time_set, ordered=True)
-    
-    def _create_demand_param(self):
-        self.model.D = pe.Param(self.model.T, initialize=dict(zip(self.model.T, self.net_demand)))
-    
-    def _create_cost_param(self):
-        self.model.C = pe.Param(self.model.U, self.model.T, initialize=self.cost_params)
 
-    
+    def _create_demand_param(self):
+        self.model.D = pe.Param(self.model.T, initialize=dict(
+            zip(self.model.T, self.net_demand)))
+
+    def _create_cost_param(self):
+        self.model.C = pe.Param(
+            self.model.U,
+            self.model.T,
+            initialize=self.cost_params)
+
     def _create_model_variables(self):
-        self.model.x = pe.Var(self.model.U, self.model.T, 
-                              domain=pe.Reals, 
+        self.model.x = pe.Var(self.model.U, self.model.T,
+                              domain=pe.Reals,
                               bounds=(self.lower_bound, self.upper_bound))
-        
+
     def _objective_function(self):
         expr = sum(self.model.C[u, t] * self.model.x[u, t]
                    for u in self.model.U for t in self.model.T)
         self.model.objective = pe.Objective(sense=pe.minimize, expr=expr)
-        
+
     def _oversupply_constraint(self):
         self.model.oversupply = pe.ConstraintList()
         for t in self.model.T:
             generation = sum(self.model.x[u, t] for u in self.model.U)
-            over_demand = self.model.D[t] * (1+self.oversupply)
+            over_demand = self.model.D[t] * (1 + self.oversupply)
             self.model.oversupply.add(generation <= over_demand)
-            
+
     def _undersupply_constraint(self):
         self.model.undersupply = pe.ConstraintList()
         for t in self.model.T:
             generation = sum(self.model.x[u, t] for u in self.model.U)
-            under_demand = self.model.D[t] * (1-self.undersupply)
+            under_demand = self.model.D[t] * (1 - self.undersupply)
             self.model.undersupply.add(generation >= under_demand)
-            
+
     def _generation_constraint(self):
         self.model.gen_limit = pe.ConstraintList()
         for t in self.model.T:
@@ -175,9 +181,8 @@ class DispatchModel():
                 unit_capacity = self.capacity_dict[u].to_value()
                 self.model.gen_limit.add(unit_generation <= unit_capacity)
 
-    
     def _write_model_equations(self):
-        
+
         self._create_model_indices()
         self._create_demand_param()
         self._create_cost_param()
@@ -186,21 +191,20 @@ class DispatchModel():
         self._oversupply_constraint()
         self._undersupply_constraint()
         self._generation_constraint()
-        
+
         return
-    
+
     def _format_results(self):
         df = pd.DataFrame(index=self.model.T)
         for u in self.model.U:
-            df[u] = [self.model.x[u,t].value for t in self.model.T]
-            
+            df[u] = [self.model.x[u, t].value for t in self.model.T]
+
         return df
-        
-        
+
     def solve(self):
         self._write_model_equations()
         solver = po.SolverFactory(self.solver)
         results = solver.solve(self.model, tee=True)
         self.objective = self.model.objective()
-        
-        self.results = self._format_results()        
+
+        self.results = self._format_results()

--- a/osier/technology.py
+++ b/osier/technology.py
@@ -113,6 +113,10 @@ def _validate_quantity(value, dimension):
 
 class Technology(object):
     """
+    The :class:`Technology` base class contains the minimum required
+    data to solve an energy systems problem. All other technologies in
+    :mod:`osier` inherit from this class.
+
     Parameters
     ----------
     technology_name : str

--- a/osier/technology.py
+++ b/osier/technology.py
@@ -3,6 +3,8 @@ from unyt import MW, hr
 from unyt import unyt_quantity
 from unyt.exceptions import UnitParseError, UnitConversionError
 
+import numpy as np
+
 
 _dim_opts = {'time': hr,
              'power': MW,
@@ -113,10 +115,21 @@ class Technology(object):
     """
     Parameters
     ----------
-    technology_name : string
+    technology_name : str
         The name identifier of the technology.
-    technology_type : string
+    technology_type : str
         The string identifier for the type of technology.
+        Two common types are: ["production", "storage"].    
+    technology_category : str
+        The string identifier the the technology category. 
+        For example: "renewable," "fossil," or "nuclear."
+    dispatchable : bool
+        Indicates whether the technology can be dispatched by a 
+        grid operator, or if it produces variable electricity
+        that must be used or stored the moment it is produced.
+        For example, solar panels and wind turbines are not 
+        dispatchable, but nuclear and biopower are dispatchable.
+        Default value is true.
     capital_cost : float or :class:`unyt.array.unyt_quantity`
         Specifies the capital cost. If float,
         the default unit is $/MW.
@@ -168,7 +181,9 @@ class Technology(object):
 
     def __init__(self,
                  technology_name,
-                 technology_type='base',
+                 technology_type='production',
+                 technology_category='base',
+                 dispatchable=True,
                  capital_cost=0.0,
                  om_cost_fixed=0.0,
                  om_cost_variable=0.0,
@@ -180,6 +195,8 @@ class Technology(object):
 
         self.technology_name = technology_name
         self.technology_type = technology_type
+        self.technology_category = technology_category
+        self.dispatchable = dispatchable
 
         self.unit_power = default_power_units
         self.unit_time = default_time_units
@@ -256,3 +273,42 @@ class Technology(object):
     @fuel_cost.setter
     def fuel_cost(self, value):
         self._fuel_cost = _validate_quantity(value, dimension="spec_energy")
+
+    @property
+    def total_capital_cost(self):
+        return self.capacity * self.capital_cost
+
+    @property
+    def annual_fixed_cost(self):
+        return self.capacity*self.om_cost_fixed
+
+    @property
+    def variable_cost(self):
+        return self.fuel_cost + self.om_cost_variable
+
+    
+    def variable_cost_ts(self, size):
+        """
+        Returns the total variable cost as a time series of 
+        length :attr:`size`. 
+        
+        .. warning:: 
+            The current implementation assumes a single constant cost 
+            for the variable cost. In the future, users will be able to 
+            pass their own time series data.
+
+        Parameters
+        ----------
+        size : int
+            The number of periods, i.e. length, of the
+            time series.
+
+        Returns
+        -------
+        var_cost_ts : :class:`numpy.ndarray`
+            The variable cost time series.
+        """
+
+        # assumes single cost
+        var_cost_ts = np.ones(size)*self.variable_cost 
+        return var_cost_ts

--- a/osier/technology.py
+++ b/osier/technology.py
@@ -66,10 +66,10 @@ def _validate_quantity(value, dimension):
     ----------
     value : string, float, int, or :class:`unyt.unyt_quantity`
         The value being tested. Should be something like
-    
+
         >>> _validate_quantity("10 MW", dimension='power')
         unyt_quantity(10., 'MW')
-        
+
     dimension : string
         The expected dimensions of `value`.
         Currently accepts: ['time', 'energy', 'power', 'spec_power', 'spec_energy'].
@@ -123,15 +123,15 @@ class Technology(object):
         The name identifier of the technology.
     technology_type : str
         The string identifier for the type of technology.
-        Two common types are: ["production", "storage"].    
+        Two common types are: ["production", "storage"].
     technology_category : str
-        The string identifier the the technology category. 
+        The string identifier the the technology category.
         For example: "renewable," "fossil," or "nuclear."
     dispatchable : bool
-        Indicates whether the technology can be dispatched by a 
+        Indicates whether the technology can be dispatched by a
         grid operator, or if it produces variable electricity
         that must be used or stored the moment it is produced.
-        For example, solar panels and wind turbines are not 
+        For example, solar panels and wind turbines are not
         dispatchable, but nuclear and biopower are dispatchable.
         Default value is true.
     capital_cost : float or :class:`unyt.array.unyt_quantity`
@@ -230,7 +230,7 @@ class Technology(object):
 
     @property
     def unit_energy(self):
-        return self._unit_power*self._unit_time
+        return self._unit_power * self._unit_time
 
     @unit_energy.setter
     def unit_energy(self, value):
@@ -284,21 +284,20 @@ class Technology(object):
 
     @property
     def annual_fixed_cost(self):
-        return self.capacity*self.om_cost_fixed
+        return self.capacity * self.om_cost_fixed
 
     @property
     def variable_cost(self):
         return self.fuel_cost + self.om_cost_variable
 
-    
     def variable_cost_ts(self, size):
         """
-        Returns the total variable cost as a time series of 
-        length :attr:`size`. 
-        
-        .. warning:: 
-            The current implementation assumes a single constant cost 
-            for the variable cost. In the future, users will be able to 
+        Returns the total variable cost as a time series of
+        length :attr:`size`.
+
+        .. warning::
+            The current implementation assumes a single constant cost
+            for the variable cost. In the future, users will be able to
             pass their own time series data.
 
         Parameters
@@ -314,5 +313,5 @@ class Technology(object):
         """
 
         # assumes single cost
-        var_cost_ts = np.ones(size)*self.variable_cost 
+        var_cost_ts = np.ones(size) * self.variable_cost
         return var_cost_ts

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ REQUIRES = [
     'dill',
     'openpyxl',
     'nrelpy',
-    'unyt']
+    'unyt',
+    'pyomo']
 EXTRAS_REQUIRE = {
     'doc': [
         'sphinx>=5.1',

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ EXTRAS_REQUIRE = {
         "sphinx_design",
         "sphinx-autodoc-typehints",
         'numpydoc',
-        'pydata_sphinx_theme', ]}
+        'pydata_sphinx_theme'
+        ]}
 PYTHON_REQUIRES = ">= 3.6"
 
 PACKAGES = find_packages()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,8 @@ if "win32" in sys.platform:
     solver = 'cplex'
 elif "linux" in sys.platform:
     solver = "cbc"
+else:
+    solver = "cbc"
 
 TOL = 1e-5
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,29 @@
+from osier import DispatchModel
+from osier import Technology
+import numpy as np
+import pytest
+
+@pytest.fixture
+def technology_set():
+    nuclear = Technology(technology_name='Nuclear',
+                     technology_type='clean',
+                     capacity=1e3,
+                     capital_cost=6,
+                     om_cost_variable=20,
+                     om_cost_fixed=50,
+                     fuel_cost=5
+                    )
+    natural_gas = Technology(technology_name='NaturalGas',
+                        technology_type='fossil',
+                        capacity=1e3,
+                        capital_cost=1,
+                        om_cost_variable=12,
+                        om_cost_fixed=30,
+                        fuel_cost=20
+                        )
+
+    return [nuclear, natural_gas]
+
+
+def test_dispatch_model(technology_set):
+    model = DispatchModel(technology_set, net_demand=np.ones(24))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ if "win32" in sys.platform:
 elif "linux" in sys.platform:
     solver = "cbc"
 
+TOL = 1e-5
 
 @pytest.fixture
 def technology_set():
@@ -45,6 +46,9 @@ def net_demand():
 
 
 def test_dispatch_model_initialize(technology_set, net_demand):
+    """
+    Tests that the dispatch model is properly initialized.
+    """
     model = DispatchModel(technology_set,
                           net_demand=net_demand,
                           solver=solver)
@@ -55,8 +59,10 @@ def test_dispatch_model_initialize(technology_set, net_demand):
     assert len(model.indices) == len(net_demand) * len(technology_set)
 
 
-@pytest.mark.skip("Does not work with CI, yet. Requires CBC or CPLEX.")
 def test_dispatch_model_solve(technology_set, net_demand):
+    """
+    Tests that the dispatch model produces expected results.
+    """
     model = DispatchModel(technology_set,
                           net_demand=net_demand,
                           solver=solver)
@@ -64,6 +70,6 @@ def test_dispatch_model_solve(technology_set, net_demand):
     cheapest_tech = unyt_array([t.variable_cost for t in technology_set]).min()
     expected_result = cheapest_tech * net_demand.sum()
 
-    assert model.objective == pytest.approx(expected_result, 0.001)
-    assert model.results['Nuclear'].sum() == net_demand.sum()
-    assert model.results['NaturalGas'].sum() == 0.0
+    assert model.objective == pytest.approx(expected_result, TOL)
+    assert model.results['Nuclear'].sum() == pytest.approx(net_demand.sum(), TOL)
+    assert model.results['NaturalGas'].sum() == pytest.approx(0.0, TOL)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,11 +2,17 @@ from osier import DispatchModel
 from osier import Technology
 import numpy as np
 import pytest
+import sys
+
+if "win32" in sys.platform:
+    solver = 'cplex'
+elif "linux" in sys.platform:
+    solver = "cbc"
 
 @pytest.fixture
 def technology_set():
     nuclear = Technology(technology_name='Nuclear',
-                     technology_type='clean',
+                     technology_type='production',
                      capacity=1e3,
                      capital_cost=6,
                      om_cost_variable=20,
@@ -14,7 +20,7 @@ def technology_set():
                      fuel_cost=5
                     )
     natural_gas = Technology(technology_name='NaturalGas',
-                        technology_type='fossil',
+                        technology_type='production',
                         capacity=1e3,
                         capital_cost=1,
                         om_cost_variable=12,
@@ -24,6 +30,19 @@ def technology_set():
 
     return [nuclear, natural_gas]
 
+@pytest.fixture
+def net_demand():
+    n_hours = 24
+    np.random.seed(123)
+    x = np.arange(0,n_hours,1)
+    y = np.sin(8*x*np.pi/180)+np.random.normal(loc=0, scale=0.1, size=n_hours)
+    y[y<0] = 0
+    return y
 
-def test_dispatch_model(technology_set):
-    model = DispatchModel(technology_set, net_demand=np.ones(24))
+
+def test_dispatch_model(technology_set, net_demand):
+    model = DispatchModel(technology_set, 
+                            net_demand=net_demand,
+                            solver=solver)
+    model.solve()
+    assert model.objective == pytest.approx(371.41, 0.05)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,7 +55,6 @@ def test_dispatch_model_initialize(technology_set, net_demand):
     assert len(model.indices) == len(net_demand) * len(technology_set)
 
 
-@pytest.mark.skip("Does not work with CI, yet. Requires CBC or CPLEX.")
 def test_dispatch_model_solve(technology_set, net_demand):
     model = DispatchModel(technology_set,
                           net_demand=net_demand,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,41 +10,44 @@ if "win32" in sys.platform:
 elif "linux" in sys.platform:
     solver = "cbc"
 
+
 @pytest.fixture
 def technology_set():
     nuclear = Technology(technology_name='Nuclear',
-                     technology_type='production',
-                     capacity=1e3,
-                     capital_cost=6,
-                     om_cost_variable=20,
-                     om_cost_fixed=50,
-                     fuel_cost=5
-                    )
+                         technology_type='production',
+                         capacity=1e3,
+                         capital_cost=6,
+                         om_cost_variable=20,
+                         om_cost_fixed=50,
+                         fuel_cost=5
+                         )
     natural_gas = Technology(technology_name='NaturalGas',
-                        technology_type='production',
-                        capacity=1e3,
-                        capital_cost=1,
-                        om_cost_variable=12,
-                        om_cost_fixed=30,
-                        fuel_cost=20
-                        )
+                             technology_type='production',
+                             capacity=1e3,
+                             capital_cost=1,
+                             om_cost_variable=12,
+                             om_cost_fixed=30,
+                             fuel_cost=20
+                             )
 
     return [nuclear, natural_gas]
+
 
 @pytest.fixture
 def net_demand():
     n_hours = 24
     np.random.seed(123)
-    x = np.arange(0,n_hours,1)
-    y = np.sin(8*x*np.pi/180)+np.random.normal(loc=0, scale=0.1, size=n_hours)
-    y[y<0] = 0
+    x = np.arange(0, n_hours, 1)
+    y = np.sin(8 * x * np.pi / 180) + \
+        np.random.normal(loc=0, scale=0.1, size=n_hours)
+    y[y < 0] = 0
     return y
 
 
 def test_dispatch_model_initialize(technology_set, net_demand):
-    model = DispatchModel(technology_set, 
-                            net_demand=net_demand,
-                            solver=solver)
+    model = DispatchModel(technology_set,
+                          net_demand=net_demand,
+                          solver=solver)
     assert model.technology_list == technology_set
     assert model.tech_set == [t.technology_name for t in technology_set]
     assert model.solver == solver
@@ -54,9 +57,9 @@ def test_dispatch_model_initialize(technology_set, net_demand):
 
 @pytest.mark.skip("Does not work with CI, yet. Requires CBC or CPLEX.")
 def test_dispatch_model_solve(technology_set, net_demand):
-    model = DispatchModel(technology_set, 
-                            net_demand=net_demand,
-                            solver=solver)
+    model = DispatchModel(technology_set,
+                          net_demand=net_demand,
+                          solver=solver)
     model.solve()
     cheapest_tech = unyt_array([t.variable_cost for t in technology_set]).min()
     expected_result = cheapest_tech * net_demand.sum()

--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -25,10 +25,12 @@ unknown_str = "10 fortnights"
 dict_type = {"value": 10,
              "unit": MW}
 
+
 @pytest.fixture
 def advanced_tech():
     PLANET_EXPRESS = Technology(TECH_NAME)
     return PLANET_EXPRESS
+
 
 def test_validate_unit():
     assert _validate_unit("MW", 'power').same_dimensions_as(Horsepower)
@@ -82,19 +84,20 @@ def test_initialize(advanced_tech):
     assert advanced_tech.annual_fixed_cost == 0.0
     assert advanced_tech.total_capital_cost == 0.0
 
+
 def test_total_capital_cost(advanced_tech):
     advanced_tech.capital_cost = spec_power_unyt
     advanced_tech.capacity = power_unyt
     assert advanced_tech.total_capital_cost == 100
 
-    advanced_tech.capacity = 0.5*power_unyt
+    advanced_tech.capacity = 0.5 * power_unyt
     assert advanced_tech.total_capital_cost == 50
-    
+
 
 def test_variable_cost(advanced_tech):
     advanced_tech.fuel_cost = spec_energy_unyt
     advanced_tech.om_cost_variable = spec_energy_unyt
-    assert advanced_tech.variable_cost == 2*spec_energy_unyt
+    assert advanced_tech.variable_cost == 2 * spec_energy_unyt
 
 
 def test_attribute_types(advanced_tech):
@@ -235,7 +238,7 @@ def test_om_cost_variable(advanced_tech):
 
     advanced_tech.unit_power = "kW"
     advanced_tech.unit_time = "day"
-    assert advanced_tech.om_cost_variable.units == (kW*day)**-1
+    assert advanced_tech.om_cost_variable.units == (kW * day)**-1
 
 
 def test_fuel_cost(advanced_tech):
@@ -264,10 +267,10 @@ def test_fuel_cost(advanced_tech):
     assert advanced_tech.fuel_cost.value == pytest.approx(
         3412141.47989694, 0.5)
     assert advanced_tech.fuel_cost.units == (MW * hr)**-1
-    
+
     advanced_tech.unit_power = "kW"
     advanced_tech.unit_time = "day"
-    assert advanced_tech.fuel_cost.units == (kW*day)**-1
+    assert advanced_tech.fuel_cost.units == (kW * day)**-1
 
 
 def test_unit_power(advanced_tech):
@@ -304,14 +307,14 @@ def test_unit_time(advanced_tech):
 
 def test_unit_energy(advanced_tech):
     advanced_tech.unit_energy = "darkmatter"
-    assert advanced_tech.unit_energy == MW*hr
+    assert advanced_tech.unit_energy == MW * hr
     advanced_tech.unit_energy = BTU
-    assert advanced_tech.unit_energy == MW*hr
+    assert advanced_tech.unit_energy == MW * hr
     advanced_tech.unit_energy = "MW"
-    assert advanced_tech.unit_energy == MW*hr
+    assert advanced_tech.unit_energy == MW * hr
     advanced_tech.unit_energy = 10
-    assert advanced_tech.unit_energy == MW*hr
+    assert advanced_tech.unit_energy == MW * hr
     advanced_tech.unit_energy = Horsepower * day
-    assert advanced_tech.unit_energy == MW*hr
+    assert advanced_tech.unit_energy == MW * hr
     advanced_tech.unit_energy = "Horsepower*day"
-    assert advanced_tech.unit_energy == MW*hr
+    assert advanced_tech.unit_energy == MW * hr

--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -79,6 +79,22 @@ def test_initialize(advanced_tech):
     assert advanced_tech.unit_power == MW
     assert advanced_tech.unit_time == hr
     assert advanced_tech.unit_energy == MW * hr
+    assert advanced_tech.annual_fixed_cost == 0.0
+    assert advanced_tech.total_capital_cost == 0.0
+
+def test_total_capital_cost(advanced_tech):
+    advanced_tech.capital_cost = spec_power_unyt
+    advanced_tech.capacity = power_unyt
+    assert advanced_tech.total_capital_cost == 100
+
+    advanced_tech.capacity = 0.5*power_unyt
+    assert advanced_tech.total_capital_cost == 50
+    
+
+def test_variable_cost(advanced_tech):
+    advanced_tech.fuel_cost = spec_energy_unyt
+    advanced_tech.om_cost_variable = spec_energy_unyt
+    assert advanced_tech.variable_cost == 2*spec_energy_unyt
 
 
 def test_attribute_types(advanced_tech):

--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -70,7 +70,7 @@ def test_validate_quantity():
 
 def test_initialize(advanced_tech):
     assert advanced_tech.technology_name == TECH_NAME
-    assert advanced_tech.technology_type == 'base'
+    assert advanced_tech.technology_type == 'production'
     assert advanced_tech.capacity == 0.0
     assert advanced_tech.capital_cost == 0.0
     assert advanced_tech.om_cost_fixed == 0.0


### PR DESCRIPTION
This pull request adds a dispatch model to osier (and appropriate tests). Closes #16. 

The PR includes the following
- a DispatchModel class that can solve a linear program
- improvements to the Technology base class to streamline the usage of the DispatchModel
- documentation for the DispatchModel, including mathematical formulation
- tests for the initialization and solve of the dispatch model.

The test `test_dispatch_model_solve` is currently skipped by pytest because it requires an external solver (e.g. cplex, CBC, GLPK) to solve and CI cannot handle it at the moment. 

I would greatly appreciate a review from @yardasol that checks the github workflow file. The current issue is that the workflow runner cannot find the CBC binaries after installation. I think it is related the different environments used to install CBC and `osier` (conda and pip, respectively) and I'm not sure how to reconcile this difference.