### PR TITLE
adds coverage and failunder to pytest command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     'pandas',
     'matplotlib',
     'pytest',
+    'pytest-cov',
     'dill',
     'openpyxl',
     'nrelpy',
@@ -67,3 +68,9 @@ doc = [
 
 [tool.setuptools.packages.find]
 include = ['osier']
+
+[tool.pytest.ini_options]
+addopts = "--cov"
+
+[tool.coverage.report]
+fail_under = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ doc = [
 include = ['osier']
 
 [tool.pytest.ini_options]
-addopts = "--cov"
+addopts = "--cov=osier tests"
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 75


### PR DESCRIPTION
Nice coverage - would be a shame if you ever let it slip...

Adds pytest-cov dependancy to default dependancies and "straps" to pytest command. So that running pytest also checks coverage.

I have added a fail for if coverage dips below 80%. This is easy to change.

