### PR TITLE
updates pyproject to find submodules and increments version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name="osier"
-version = "0.4.1"
+version = "0.4.2"
 description = "osier: A justice oriented energy system optimization tool"
 readme = "README.md"
 keywords = ["energy systems", "optimization", "multi-objective", "justice", "multi-criteria decision"]


### PR DESCRIPTION
This PR addresses a silent issue that broke installations from PyPI directly (i.e., `pip install osier`). 

This issue is fixed by updating the `pyproject.toml` file.

(Actually, I was naughty and pushed the actual fix earlier... this PR just increments the version number. Oops.)